### PR TITLE
Added support for the Paginating event retrieval API.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,7 @@
 # go-loggly-search
 
  Loggly search client for Go.
+ Now supports Paginating Event Retrieval API (uses it by default).
 
 ## Example
 
@@ -10,6 +11,14 @@
 
 ```go
 client := search.New("accountname", "username", "password")
+res, err := client.Query(`(login OR logout) AND tobi`).Size(50).From("-5h").Fetch()
+```
+
+  If you need to use Single-block event retrieval API:
+
+```go
+client := search.New("accountname", "username", "password")
+client.Paginating = false
 res, err := client.Query(`(login OR logout) AND tobi`).Size(50).From("-5h").Fetch()
 ```
 

--- a/search.go
+++ b/search.go
@@ -6,14 +6,16 @@ import "net/http"
 import "net/url"
 import "strconv"
 import "fmt"
+import "strings"
 
 // Loggly search client with user credentials, loggly
 // does not seem to support tokens right now.
 type Client struct {
-	User     string
-	Pass     string
-	Account  string
-	Endpoint string
+	User       string
+	Pass       string
+	Account    string
+	Endpoint   string
+	Paginating bool
 }
 
 // Search response with total events, page number
@@ -22,6 +24,7 @@ type Response struct {
 	Total  int64
 	Page   int64
 	Events []interface{}
+	Url    string
 }
 
 // Query builder struct
@@ -49,10 +52,11 @@ func newQuery(c *Client, str string) *query {
 // Create a new loggly search client with credentials.
 func New(account string, user string, pass string) *Client {
 	c := &Client{
-		Account:  account,
-		User:     user,
-		Pass:     pass,
-		Endpoint: "loggly.com/apiv2",
+		Account:    account,
+		User:       user,
+		Pass:       pass,
+		Endpoint:   "loggly.com/apiv2",
+		Paginating: true,
 	}
 
 	return c
@@ -95,7 +99,16 @@ func (c *Client) GetJSON(path string) (j *simplejson.Json, err error) {
 // Create a new search instance, loggly requires that a search
 // is made before you may fetch events from it with a second call.
 func (c *Client) CreateSearch(params string) (*simplejson.Json, error) {
-	return c.GetJSON("/search?" + params)
+	if c.Paginating {
+		return c.GetJSON("/events/iterate?" + params)
+	} else {
+		return c.GetJSON("/search?" + params)
+	}
+}
+
+// Create a next paginating search instance.
+func (c *Client) CreateNextSearch(params string) (*simplejson.Json, error) {
+	return c.GetJSON("/events/iterate?next=" + params)
 }
 
 // Get events, must be called after CreateSearch() with the
@@ -113,20 +126,46 @@ func (c *Client) Search(params string) (*Response, error) {
 		return nil, err
 	}
 
-	id := j.GetPath("rsid", "id").MustString()
-	j, err = c.GetEvents("rsid=" + id)
+	urlNext := ""
 
-	if err != nil {
-		return nil, err
+	if c.Paginating {
+		urlNext = j.Get("next").MustString()
+	} else {
+		id := j.GetPath("rsid", "id").MustString()
+		j, err = c.GetEvents("rsid=" + id)
+		
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Search response with total events, page number
 	// and the events array.
-	return &Response{
-		Total:  j.Get("total_events").MustInt64(),
-		Page:   j.Get("page").MustInt64(),
-		Events: j.Get("events").MustArray(),
-	}, nil
+	if c.Paginating {
+		response := &Response{
+			Events: j.Get("events").MustArray(),
+			Url:    urlNext,
+		}
+
+		for response.Url != "" {
+			s := strings.Split(response.Url, "=")
+    		nextID := s[1]
+    		
+    		j, err = c.CreateNextSearch(nextID)
+    		if err != nil {
+				return nil, err
+			}
+    		response.Url = j.Get("next").MustString()
+    		response.Events = append (response.Events, j.Get("events").MustArray()...)
+		}
+		return response, nil
+	} else {
+		return &Response{
+			Total:  j.Get("total_events").MustInt64(),
+			Page:   j.Get("page").MustInt64(),
+			Events: j.Get("events").MustArray(),
+		}, nil
+	}
 }
 
 // Create a new search query using the fluent api.

--- a/search.go
+++ b/search.go
@@ -39,13 +39,13 @@ type query struct {
 }
 
 // Create a new query
-func newQuery(c *Client, str string) *query {
+func newQuery(c *Client, str string, ord string) *query {
 	return &query{
 		client: c,
 		query:  str,
 		from:   "-24h",
 		until:  "now",
-		order:  "asc",
+		order:  ord,
 		size:   100,
 	}
 }
@@ -135,7 +135,7 @@ func (c *Client) Search(params string) (*Response, error) {
 	} else {
 		id := j.GetPath("rsid", "id").MustString()
 		j, err = c.GetEvents("rsid=" + id)
-		
+
 		if err != nil {
 			return nil, err
 		}
@@ -151,14 +151,14 @@ func (c *Client) Search(params string) (*Response, error) {
 		if c.GetAllAtOnce {
 			for response.Url != "" {
 				s := strings.Split(response.Url, "=")
-    			nextID := s[1]
-    		
-    			j, err = c.CreateNextSearch(nextID)
-    			if err != nil {
+				nextID := s[1]
+
+				j, err = c.CreateNextSearch(nextID)
+				if err != nil {
 					return nil, err
 				}
-    			response.Url = j.Get("next").MustString()
-    			response.Events = append (response.Events, j.Get("events").MustArray()...)
+				response.Url = j.Get("next").MustString()
+				response.Events = append(response.Events, j.Get("events").MustArray()...)
 			}
 		}
 		return response, nil
@@ -176,7 +176,7 @@ func (c *Client) Search(params string) (*Response, error) {
 // contains url for the next part of events
 func (c *Client) NextSearch(nextID string) (*Response, error) {
 	j, err := c.CreateNextSearch(nextID)
-   	if err != nil {
+	if err != nil {
 		return nil, err
 	}
 	return &Response{
@@ -186,8 +186,8 @@ func (c *Client) NextSearch(nextID string) (*Response, error) {
 }
 
 // Create a new search query using the fluent api.
-func (c *Client) Query(str string) *query {
-	return newQuery(c, str)
+func (c *Client) Query(str string, order string) *query {
+	return newQuery(c, str, order)
 }
 
 // Return the encoded query-string.


### PR DESCRIPTION
Since it's noted at the Loggly documentation that the Single-block event retrieval API is deprecated and will be End of Life (EOL) on January 1, 2018, it's recommend to migrate to the Paginating event retrieval API.